### PR TITLE
fix dead links because of caching change

### DIFF
--- a/files/routes/static.py
+++ b/files/routes/static.py
@@ -16,6 +16,24 @@ def rdrama(id, title):
 	id = ''.join(f'{x}/' for x in id)
 	return redirect(f'/archives/drama/comments/{id}{title}.html')
 
+@app.get('/logged_out/')
+@app.get('/logged_out/<path:old>')
+def logged_out(old = ""):
+        # Remove trailing question mark from request.full_path which flask adds if there are no query parameters
+        redirect_url = request.full_path.replace("/logged_out", "", 1)
+        if redirect_url.endswith("?"):
+            redirect_url = redirect_url[:-1]
+
+        # Handle cases like /logged_out?asdf by adding a slash to the beginning
+        if not redirect_url.startswith('/'):
+            redirect_url = f"/{redirect_url}"
+
+        # Prevent redirect loop caused by visiting /logged_out/logged_out/logged_out/etc...
+        if redirect_url.startswith('/logged_out'):
+            abort(400)
+
+        return redirect(redirect_url)
+
 @app.get("/privacy")
 @auth_required
 def privacy(v):


### PR DESCRIPTION
adds a redirect to the old /logged_out directory to fix links that were crawled by search engines, or bookmarked/shared by logged out users

example of dead links: https://www.google.com/search?q=site%3Ardrama.net%2Flogged_out