### PR TITLE
Add dynamic journoid banner text.

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -4759,6 +4759,7 @@ img.golden, img[g] {
 .bg-muted {
 	background-color: #6c757d !important;
 }
+
 .srd {
 	width: 100%;
 	background-color: var(--primary);
@@ -4767,6 +4768,13 @@ img.golden, img[g] {
 	font-weight: bold;
 	white-space: nowrap;
 }
+.srd > a {
+	color: white;
+}
+#srd-discuss {
+	font-weight: normal;
+}
+
 @media (max-width: 768px) {
 	.toast {
 		bottom: 5rem !important;

--- a/files/templates/header.html
+++ b/files/templates/header.html
@@ -21,11 +21,8 @@
 	{% endif %}
 
 	{% if SITE_NAME == 'rDrama' %}
-		<div class="srd">
-			<a style="color: white" class="text-small-mobile" href="https://www.independent.co.uk/news/world/americas/us-politics/reddit-conservatives-post-trans-child-fake-b2060803.html">As seen on The Independent 📰✨💞</a>
-		</div>
+		{% include "journoid_banner.html" %}
 	{% endif %}
-
 
 	<div class="navbar navbar-expand-md navbar-light" id="navbar">
 		<div class="container-fluid" style="padding:0;">

--- a/files/templates/journoid_banner.html
+++ b/files/templates/journoid_banner.html
@@ -1,0 +1,30 @@
+{# JournoidBanner Index (keep updated for clarity's sake):
+	[0] TransParentTransKid (good coverage) on the Independent
+	[1] TransParentTransKid (lol coverage) on Reuters
+	[2] "Furry Culture Month" baited Libs of TikTok on Mashable
+#}
+{% set JOURNOID_BANNERS = [
+	( 
+		"As seen on The Independent 📰✨💞", 
+		"https://www.independent.co.uk/news/world/americas/us-politics/reddit-conservatives-post-trans-child-fake-b2060803.html", 
+		"/post/61530/"
+	),
+	(
+		"Has been fact-checked by Reuters 📰", 
+		"https://www.reuters.com/article/factcheck-socialmedia-gender/fact-check-post-about-parent-forcefully-medicating-transgender-child-is-fabricated-idUSL2N2WC1OK", 
+		"/post/60443/"
+	),
+	(
+		"As seen on Mashable & Libs of TikTok 📰✨", 
+		"https://mashable.com/article/libs-of-tiktok-furries-school-troll-fake", 
+		"/post/63155/"
+	),
+]
+%}
+
+{% set journoid = JOURNOID_BANNERS|random %}
+<div class="srd">
+	<a id="srd-link" class="text-small-mobile" href="{{ journoid[1] }}">{{ journoid[0] }}</a>
+	<span id="srd-separator">&mdash;</span>
+	<a id="srd-discuss" class="text-small-mobile" href="{{ journoid[2] }}">(discuss)</a>
+</div>


### PR DESCRIPTION
The .srd header banner currently has fixed text. However, there have
been many gayops which have made the news. journoid_banner.html is a
dynamic template which selects a random one to present.

Also, stylesheets and markup for the banner have been unslurred.