### PR TITLE
Fix comment self-upvote removal UI bug.

### DIFF
--- a/files/routes/votes.py
+++ b/files/routes/votes.py
@@ -68,26 +68,30 @@ def api_vote_post(post_id, new, v):
 
 	existing = g.db.query(Vote).filter_by(user_id=v.id, submission_id=post.id).one_or_none()
 
+	coin_delta = 1
+	if v.id == post.author.id:
+		coin_delta = 0
+
 	if existing and existing.vote_type == new: return "", 204
 
 	if existing:
 		if existing.vote_type == 0 and new != 0:
-			post.author.coins += 1
-			post.author.truecoins += 1
+			post.author.coins += coin_delta
+			post.author.truecoins += coin_delta
 			g.db.add(post.author)
 			existing.vote_type = new
 			g.db.add(existing)
 		elif existing.vote_type != 0 and new == 0:
-			post.author.coins -= 1
-			post.author.truecoins -= 1
+			post.author.coins -= coin_delta
+			post.author.truecoins -= coin_delta
 			g.db.add(post.author)
 			g.db.delete(existing)
 		else:
 			existing.vote_type = new
 			g.db.add(existing)
 	elif new != 0:
-		post.author.coins += 1
-		post.author.truecoins += 1
+		post.author.coins += coin_delta
+		post.author.truecoins += coin_delta
 		g.db.add(post.author)
 
 		if new == 1 and (v.agendaposter or v.shadowbanned or (v.is_banned and not v.unban_utc) or (v.profile_url.startswith('/e/') and not v.customtitle and v.namecolor == DEFAULT_COLOR)): real = False
@@ -132,26 +136,30 @@ def api_vote_comment(comment_id, new, v):
 	
 	existing = g.db.query(CommentVote).filter_by(user_id=v.id, comment_id=comment.id).one_or_none()
 
+	coin_delta = 1
+	if v.id == comment.author_id:
+		coin_delta = 0
+
 	if existing and existing.vote_type == new: return "", 204
 
 	if existing:
 		if existing.vote_type == 0 and new != 0:
-			comment.author.coins += 1
-			comment.author.truecoins += 1
+			comment.author.coins += coin_delta
+			comment.author.truecoins += coin_delta
 			g.db.add(comment.author)
 			existing.vote_type = new
 			g.db.add(existing)
 		elif existing.vote_type != 0 and new == 0:
-			comment.author.coins -= 1
-			comment.author.truecoins -= 1
+			comment.author.coins -= coin_delta
+			comment.author.truecoins -= coin_delta
 			g.db.add(comment.author)
 			g.db.delete(existing)
 		else:
 			existing.vote_type = new
 			g.db.add(existing)
 	elif new != 0:
-		comment.author.coins += 1
-		comment.author.truecoins += 1
+		comment.author.coins += coin_delta
+		comment.author.truecoins += coin_delta
 		g.db.add(comment.author)
 
 		if new == 1 and (v.agendaposter or v.shadowbanned or (v.is_banned and not v.unban_utc) or (v.profile_url.startswith('/e/') and not v.customtitle and v.namecolor == DEFAULT_COLOR)): real = False

--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -112,9 +112,6 @@
 
 {% if v %}
 	{% set voted=c.voted %}
-	{% if not voted and v.id == c.author_id %}
-		{% set voted=1 %}
-	{% endif %}
 {% else %}
 	{% set voted=-2 %}
 {% endif %}


### PR DESCRIPTION
<pre>Fixes minor UI bug when removing self-upvote on a comment. Previous
behavior, starting from a new comment:
    - Initial state: score 1 from self-upvote, upvote button shows
      highlighted as `color: var(--primary)`.
    - Click on upvote button to remove self-upvote → button
      unhighlights, score displays as 0.
    - [reload page]
    - Score displays as 0, but button is highlighted.
    - Click on upvote button → button unhighlights, score displays
      as -1. [If you reload the page now, state is score 0 &
      highlighted; no change in serverside votes.]
    - Click on upvote again → button highlights, score displays as 0.
    - [reload page]
    - Score displays as 1, button is highlighted.
Direct cause is `templates/comments.html @ L115-117`. I checked
`api_comment`, though, and it adds a vote on new comments, and that
state change propagates to the template's parameters before it renders,
so I believe the only time this triggers is specifically when a user
has removed their self-upvote. Bug is fixed when testing with L115-117
removed. Is there some other edge case it was meant to solve?

Secondary bugfix: Removing a self-upvote _costs_ you a coin & a
truescore point. I think this is one of the few ways to get negative
dramacoin. I chose to fix it by having self-votes and self-unvotes not
change coins/truecoins. The alternative of having new comments & posts
give the user +1 coin/truecoin would modify site behavior, and you'd
retroactively owe some powerusers thousands of DC & truescore.</pre>