### PR TITLE
Partially revert self-upvote UI bug fix.

### DIFF
--- a/files/templates/comments.html
+++ b/files/templates/comments.html
@@ -112,6 +112,9 @@
 
 {% if v %}
 	{% set voted=c.voted %}
+	{% if not voted and v.id == c.author_id %}
+		{% set voted=1 %}
+	{% endif %}
 {% else %}
 	{% set voted=-2 %}
 {% endif %}


### PR DESCRIPTION
<pre>Turns out the snippet in templates/comments.html was necessary to
get proper behavior in notifications.

Might come back to debug this later, but people use notifications more
than they deal with edge case self-upvotes, so reverting for now.

The changes to prevent coin fuckery with self-upvoting appear to work
correctly in the wild, so leaving those in place.</pre>