### PR TITLE
Add admin status git revision.

### DIFF
--- a/files/templates/admin/admin_home.html
+++ b/files/templates/admin/admin_home.html
@@ -85,7 +85,12 @@
 		<label class="custom-control-label" for="under_attack">Under attack mode</label>
 	</div>
 
-	<button class="btn btn-primary mt-3" onclick="post_toast(this,'/admin/purge_cache');">PURGE CACHE</button>
+	<button class="btn btn-primary mt-3" onclick="post_toast(this,'/admin/purge_cache');" style="margin-bottom: 2em;">PURGE CACHE</button>
 {% endif %}
+
+<h4>Server Status</h4>
+<div>
+	Live Revision: <code>{{ gitref }}</code> <br>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
<pre>Adds a line in admin_home which displays the currently active git
revision. Current methodology is via manually parsing files in .git.
Consider revising if the application ever has access to `git` shell,
which would obviate some minor security concerns around directory
traversal attacks.</pre>