### PR TITLE
Switch to marsey.cat for Snappy /u/.

### DIFF
--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -1299,7 +1299,7 @@ def submit_post(v, sub=None):
 				rev = f"* [unddit.com](https://unddit.com/{rev})\n"
 			elif post.url.startswith("https://old.reddit.com/u/"):
 				rev = post.url.replace('https://old.reddit.com/u/', '')
-				rev = f"* [camas.github.io](https://camas.github.io/reddit-search/#\u007b\"author\":\"{rev}\",\"resultSize\":100\u007d)\n"
+				rev = f"* [search.marsey.cat](https://search.marsey.cat/reddit-search/#\u007b\"author\":\"{rev}\",\"resultSize\":100\u007d)\n"
 			else: rev = ''
 			
 			newposturl = post.url
@@ -1324,7 +1324,7 @@ def submit_post(v, sub=None):
 					body += f'* [unddit.com](https://unddit.com/{href.replace("https://old.reddit.com/", "")})\n'
 				if href.startswith('https://old.reddit.com/u/'):
 					rev = post.url.replace('https://old.reddit.com/u/', '')
-					body += f"* [camas.github.io](https://camas.github.io/reddit-search/#\u007b\"author\":\"{rev}\",\"resultSize\":100\u007d)\n"
+					body += f"* [search.marsey.cat](https://search.marsey.cat/reddit-search/#\u007b\"author\":\"{rev}\",\"resultSize\":100\u007d)\n"
 				body += f'* [archive.org](https://web.archive.org/{href})\n'
 				body += f'* [archive.ph](https://archive.ph/?url={quote(href)}&run=1) (click to archive)\n'
 				body += f'* [ghostarchive.org](https://ghostarchive.org/search?term={quote(href)}) (click to archive)\n\n'

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -1321,9 +1321,10 @@ def submit_post(v, sub=None):
 			if f'**[{title}]({href})**:\n\n' not in body:
 				body += f'**[{title}]({href})**:\n\n'
 				if href.startswith('https://old.reddit.com/r/'):
-					body += f'* [unddit.com](https://unddit.com/{href.replace("https://old.reddit.com/", "")})\n'
+					rev = href.replace('https://old.reddit.com/', '')
+					body += f'* [unddit.com](https://unddit.com/{rev})\n'
 				if href.startswith('https://old.reddit.com/u/'):
-					rev = post.url.replace('https://old.reddit.com/u/', '')
+					rev = href.replace('https://old.reddit.com/u/', '')
 					body += f"* [search.marsey.cat](https://search.marsey.cat/reddit-search/#\u007b\"author\":\"{rev}\",\"resultSize\":100\u007d)\n"
 				body += f'* [archive.org](https://web.archive.org/{href})\n'
 				body += f'* [archive.ph](https://archive.ph/?url={quote(href)}&run=1) (click to archive)\n'


### PR DESCRIPTION
<pre>camas is down, replacing it with search.marsey.cat.
Note that when looking for existing Snappy comments to test against,
it appears that something else with Snappy generation is broken.

Ex: /post/66263/-/1876803 puts an entire post URL in the author field.
This commit makes no attempt to fix this. TODO for later.</pre>

<pre>Following up on previous commit:
Issue was that author was being extracted from post.url, not href.
Given that the relevant code section is specifically for /u/s in the
body text of the submission, this was a problem.</pre>