### PR TITLE
Add <audio> and FA icons to sanitize.py.

### DIFF
--- a/files/helpers/sanitize.py
+++ b/files/helpers/sanitize.py
@@ -60,8 +60,20 @@ def allowed_attributes(tag, name, value):
 		if name == 'src' and embed_fullmatch_regex.fullmatch(value): return True
 		return False
 
+	if tag == 'audio':
+		if name == 'controls' and value == '': return True
+		if name == 'preload' and value == 'none': return True
+		if name == 'src' and embed_fullmatch_regex.fullmatch(value): return True
+		return False
+
 	if tag == 'p':
 		if name == 'class' and value == 'mb-0': return True
+		return False
+
+	if tag == 'i':
+		if name == 'class' and \
+			sorted(value.split())[0][:3] == 'fa-' and \
+			sorted(value.split())[1:] == ['fas', 'px-1', 'text-black']: return True
 		return False
 
 	if tag == 'span':


### PR DESCRIPTION
<pre>&lt;audio&gt;: Parallels the decisions made with &lt;video&gt; & &lt;source&gt;.
Not tested terribly thoroughly, but looks fine.

FA icons: niche use case and designed perhaps over-restrictively.
May be useful later, who knows.</pre>