### PR TITLE
Fix profile CSS on localhost

### DIFF
--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -541,8 +541,9 @@ def leaderboard(v):
 @app.get("/@<username>/css")
 def get_css(username):
 	user = get_user(username)
-	resp=make_response(user.css or "")
-	resp.headers.add("Content-Type", "text/css")
+	resp = make_response(user.css or "")
+	resp.headers["Content-Type"] = "text/css"
+	resp.headers["Referrer-Policy"] = "no-referrer"
 	return resp
 
 @app.get("/@<username>/profilecss")
@@ -550,8 +551,9 @@ def get_profilecss(username):
 	user = get_user(username)
 	if user.profilecss: profilecss = user.profilecss
 	else: profilecss = ""
-	resp=make_response(profilecss)
-	resp.headers.add("Content-Type", "text/css")
+	resp = make_response(profilecss)
+	resp.headers["Content-Type"] = "text/css"
+	resp.headers["Referrer-Policy"] = "no-referrer"
 	return resp
 
 @app.get("/id/<id>/profilecss")
@@ -559,8 +561,9 @@ def get_profilecss_id(id):
 	user = get_account(id)
 	if user.profilecss: profilecss = user.profilecss
 	else: profilecss = ""
-	resp=make_response(profilecss)
-	resp.headers.add("Content-Type", "text/css")
+	resp = make_response(profilecss)
+	resp.headers["Content-Type"] = "text/css"
+	resp.headers["Referrer-Policy"] = "no-referrer"
 	return resp
 
 @app.get("/@<username>/song")


### PR DESCRIPTION
Custom profile CSS wouldn't load for me with the two Content-Type headers:

<img width="286" alt="image" src="https://user-images.githubusercontent.com/102226344/167953567-3c8d2131-76b7-47b1-ba1c-28e1e8641916.png">

 Also adds Referrer-Policy for content fetched within the CSS