### PR TITLE
Also check KeyboardEvent.metaKey for the post shortcut.

### DIFF
--- a/files/assets/js/shortcut handler.js
+++ b/files/assets/js/shortcut handler.js
@@ -21,7 +21,7 @@ Copyright (C) 2022 Dr Steven Transmisia, anti-evil engineer
  * @param {KeyboardEvent} e
  */
 document.addEventListener('keydown', (e) => {
-	if(!(e.ctrlKey && e.key == "Enter"))
+	if(!((e.ctrlKey || e.metaKey) && e.key === "Enter"))
 		return;
 	
 	/** @type {HTMLTextAreaElement} */


### PR DESCRIPTION
macOS and iOS usually have their shortcut keys using the command key instead of control (e.g. Microsoft Word on Windows binds print to Ctrl+P while the Mac version uses Command+P). Checking KeyboardEvent.metaKey will allow Mac and iOS users to use the command key for the post shortcut which is more comfortable.