### PR TITLE
Remove margin-bottom on header tags in blockquotes

### DIFF
--- a/files/assets/css/main.css
+++ b/files/assets/css/main.css
@@ -66,6 +66,9 @@ dd {
 blockquote {
 	margin: 0 0 1rem;
 }
+blockquote :is(h1, h2, h3, h4, h5, h6) {
+	margin-bottom: 0;
+}
 b, strong {
 	font-weight: 700;
 }

--- a/files/templates/util/assetcache.html
+++ b/files/templates/util/assetcache.html
@@ -1,6 +1,6 @@
 {%-
 set CACHE_VER = {
-	'css/main.css': 291,
+	'css/main.css': 292,
 
 	'css/4chan.css': 59,
 	'css/classic.css': 59,


### PR DESCRIPTION
 Before:

![before](https://user-images.githubusercontent.com/102226344/171340615-a519fea9-d4fb-41a8-8335-0b356577cf7d.png)

After:

![after](https://user-images.githubusercontent.com/102226344/171340628-87e70184-f63c-49fc-adc4-8e3c46b8fae9.png)