### PR TITLE
fix exceptions in sanitize leaving SIGALRM on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ venv/
 flask_session/
 .DS_Store
 site_settings.json
+/files/test.py
+tags


### PR DESCRIPTION
While messing with a long string of `>` causing a RecursionLimitExceeded in `mistletoe` (harmless) I discovered that this (or any other) exception in `sanitize` will leave SIGALRM on, causing another exception later, restarting the server or aborting another request. This fixes it.