### PR TITLE
Redirect cuts off end of url for username redirect

### DIFF
--- a/files/routes/users.py
+++ b/files/routes/users.py
@@ -922,7 +922,7 @@ def u_username(username, v=None):
 
 
 	if username != u.username:
-		return redirect(SITE_FULL + request.full_path.replace(username, u.username)[:-1])
+		return redirect(SITE_FULL + request.full_path.replace(username, u.username))
 
 	if u.reserved:
 		if request.headers.get("Authorization") or request.headers.get("xhr") or request.path.endswith(".json"):


### PR DESCRIPTION
username redirect cuts 1 character off end of url, For example:

Username: faygo_sucks
Old_username: geese_suck
Behavior:          "https://rdrama.net/@geese_suck" -> "https://rdrama.net/@faygo_suck"
Expected Behavior: "https://rdrama.net/@geese_suck" -> "https://rdrama.net/@faygo_sucks"