### PR TITLE
don't constantly check for reposts when it's obvious there can't be one

### DIFF
--- a/files/assets/js/submit.js
+++ b/files/assets/js/submit.js
@@ -163,8 +163,9 @@ function checkRepost() {
 	const system = document.getElementById('system')
 	system.innerHTML = `To post an image, use a direct image link such as i.imgur.com`;
 	const url = document.getElementById('post-url').value
+	const min_repost_check = 9;
 
-	if (url) {
+	if (url && url.length >= min_repost_check) {
 		const xhr = new XMLHttpRequest();
 		xhr.open("post", "/is_repost");
 		xhr.setRequestHeader('xhr', 'xhr');

--- a/files/helpers/const.py
+++ b/files/helpers/const.py
@@ -333,6 +333,7 @@ COMMENT_BODY_LENGTH_LIMIT = 10000 # do not make larger than 10000 characters wit
 COMMENT_BODY_HTML_LENGTH_LIMIT = 20000 # do not make larger than 20000 characters without altering the table
 COMMENT_MAX_DEPTH = 200
 TRANSFER_MESSAGE_LENGTH_LIMIT = 200 # do not make larger than 10000 characters (comment limit) without altering the table
+MIN_REPOST_CHECK_URL_LENGTH = 9 # also change the constant in checkRepost() of submit.js
 
 LOGGEDIN_ACTIVE_TIME = 15 * 60
 PFP_DEFAULT_MARSEY = True

--- a/files/routes/posts.py
+++ b/files/routes/posts.py
@@ -652,11 +652,12 @@ def thumbnail_thread(pid):
 
 @app.post("/is_repost")
 def is_repost():
+	not_a_repost = {'permalink': ''}
 	if not FEATURES['REPOST_DETECTION']:
-		return {'permalink': ''}
+		return not_a_repost
 
 	url = request.values.get('url')
-	if not url: abort(400)
+	if not url or len(url) < MIN_REPOST_CHECK_URL_LENGTH: abort(400)
 
 	url = normalize_url(url)
 	parsed_url = urlparse(url)
@@ -681,7 +682,6 @@ def is_repost():
 							fragment=parsed_url.fragment)
 	
 	url = urlunparse(new_url)
-
 	url = url.rstrip('/')
 
 	search_url = url.replace('%', '').replace('\\', '').replace('_', '\_').strip()
@@ -691,7 +691,7 @@ def is_repost():
 		Submission.is_banned == False
 	).first()
 	if repost: return {'permalink': repost.permalink}
-	else: return {'permalink': ''}
+	else: return not_a_repost
 
 @app.post("/submit")
 @app.post("/h/<sub>/submit")


### PR DESCRIPTION
we currently spam the /is_repost api on every single character change in the URL box even though there is no way these URLs would ever be submitted to the site

introducing a frankly conservative limit to where we start actually pinging both the api and (on the backend) the database for reposts may help in some cases

the current constant was chosen by taking the length of "http://" and adding 2 to it